### PR TITLE
add in check to make sure pjson.jspm.directories.baseURL exists

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -9,7 +9,7 @@ var buildConfig = require('./buildConfig');
 function inferBaseUrl() {
     var pjson = require(path.join(process.cwd(), 'package.json'));
 
-    if(pjson && pjson.jspm && pjson.jspm.directories) {
+    if(pjson && pjson.jspm && pjson.jspm.directories && pjson.jspm.directories.baseURL != undefined) {
         return pjson.jspm.directories.baseURL;
     }
     return '.';


### PR DESCRIPTION
it is not guaranteed to exist and isn't required to exist if directories does:
https://github.com/jspm/registry/wiki/Configuring-Packages-for-jspm#package-files
